### PR TITLE
Updated to allow users to specify a context path

### DIFF
--- a/tasks/slang.js
+++ b/tasks/slang.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
         var PORT = options.port || 4502;
         var USER = options.user || 'admin';
         var PASS = options.pass || 'admin';
+        var CONTEXT = options.context;
 
         // if jcr_root is in file system path, remove before setting destination
         destPath = localPath;
@@ -27,7 +28,7 @@ module.exports = function(grunt) {
 
         // create full URL for curl path
         var URL = 'http://' + USER + ':' + PASS + '@' + HOST + ':' + PORT + '/' +
-            path.dirname(destPath) + '.json';
+                  (CONTEXT ?  CONTEXT + '/' : '') + path.dirname(destPath) + '.json';
 
         requestOptions = {
             url: URL,


### PR DESCRIPTION
Our AEM install changed to require a context path (-c somePath). This broke the sling plugin. I wrote this up real fast to fix the issue.
